### PR TITLE
fix notices with latest V, run `v fmt -w .`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Latest V
+        uses: actions/checkout@v4
+        with:
+          repository: vlang/v
+          path: v
+      - name: Build V
+        run: cd v && make && ./v symlink
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Symlink to ~/.vmodules/vpng
+        run: ln -s $(realpath .) ~/.vmodules/vpng
+
+      - name: Ensure code is formatted
+        run: v fmt -verify .
+
+      - name: Run tests
+        run: v test .
+
+      - name: Ensure examples compile
+        run: v should-compile-all examples/
+
+      - name: Print V logo
+        run: v run examples/png-printer.v examples/v-logo-small.png

--- a/crc.v
+++ b/crc.v
@@ -4,11 +4,11 @@ module vpng
 
 pub struct CRC {
 mut:
-	crc_table []u64 = []u64{len: 256}
+	crc_table          []u64 = []u64{len: 256}
 	crc_table_computed int
 }
 
-fn (mut cs CRC)make_crc_table() {
+fn (mut cs CRC) make_crc_table() {
 	mut c := u64(0)
 	mut n := int(0)
 	mut k := int(0)
@@ -17,7 +17,7 @@ fn (mut cs CRC)make_crc_table() {
 		c = u64(n)
 		for k = 0; k < 8; k++ {
 			if c & 1 != 0 {
-				c = /**/u64(i64(0xedb88320) ^ /**/i64(c >> 1))
+				c = u64(i64(0xedb88320) ^ i64(c >> 1))
 			} else {
 				c = c >> 1
 			}
@@ -27,7 +27,7 @@ fn (mut cs CRC)make_crc_table() {
 	cs.crc_table_computed = 1
 }
 
-fn (mut cs CRC)update_crc(crc u64, buf []u8, len int) u64 {
+fn (mut cs CRC) update_crc(crc u64, buf []u8, len int) u64 {
 	mut c := u64(crc)
 	mut n := int(0)
 
@@ -40,6 +40,6 @@ fn (mut cs CRC)update_crc(crc u64, buf []u8, len int) u64 {
 	return c
 }
 
-pub fn (mut cs CRC)crc(buf []u8, len int) u64 {
+pub fn (mut cs CRC) crc(buf []u8, len int) u64 {
 	return cs.update_crc(u64(0xffffffff), buf, len) ^ u64(0xffffffff)
 }

--- a/examples/png-printer.v
+++ b/examples/png-printer.v
@@ -12,7 +12,7 @@ fn pixel_print_hd(x int, y int, png vpng.PngFile) {
 		return
 	}
 	top_pixel := png.pixels[y * png.width + x]
-	mut top_str := ""
+	mut top_str := ''
 	match top_pixel {
 		vpng.TrueColor {
 			top_str = term.rgb(top_pixel.red, top_pixel.green, top_pixel.blue, '▀')
@@ -21,7 +21,7 @@ fn pixel_print_hd(x int, y int, png vpng.PngFile) {
 			top_str = term.rgb(top_pixel.red, top_pixel.green, top_pixel.blue, '▀')
 		}
 		else {
-			""
+			''
 		}
 	}
 	if y + 1 >= png.height {
@@ -29,7 +29,7 @@ fn pixel_print_hd(x int, y int, png vpng.PngFile) {
 		return
 	}
 	bot_pixel := png.pixels[(y + 1) * png.width + x]
-	mut bot_str := ""
+	mut bot_str := ''
 	match bot_pixel {
 		vpng.TrueColor {
 			bot_str = term.bg_rgb(bot_pixel.red, bot_pixel.green, bot_pixel.blue, top_str)
@@ -38,7 +38,7 @@ fn pixel_print_hd(x int, y int, png vpng.PngFile) {
 			bot_str = term.bg_rgb(bot_pixel.red, bot_pixel.green, bot_pixel.blue, top_str)
 		}
 		else {
-			""
+			''
 		}
 	}
 	print(bot_str)
@@ -47,7 +47,7 @@ fn pixel_print_hd(x int, y int, png vpng.PngFile) {
 fn hi_res_print(png vpng.PngFile) {
 	mut x := 0
 	mut y := 0
-	
+
 	for y < png.height {
 		x = 0
 		for x < png.width {
@@ -62,11 +62,9 @@ fn hi_res_print(png vpng.PngFile) {
 fn main() {
 	if os.args.len != 2 {
 		println('Missing filename')
-		return
+		exit(1)
 	}
 	filename := os.args[1]
-	png := vpng.read(filename) or {
-		return
-	}
+	png := vpng.read(filename)!
 	hi_res_print(png)
 }

--- a/examples/redline.v
+++ b/examples/redline.v
@@ -10,34 +10,23 @@ fn main() {
 	if os.args.len != 3 {
 		println('Missing filename')
 		println('./redline input.png output.png')
-		return
+		exit(1)
 	}
-	mut png := vpng.read(os.args[1]) or {
-		return
-	}
+	mut png := vpng.read(os.args[1])!
 	mut min := png.width
 	if png.height < png.width {
 		min = png.height
 	}
-	for i in 0..min {
+	for i in 0 .. min {
 		pos := i * png.width + i
 		match png.pixel_type {
 			.truecolor {
-				png.pixels[pos] = vpng.TrueColor {
-					255,
-					0,
-					0,
-				}
+				png.pixels[pos] = vpng.TrueColor{255, 0, 0}
 			}
 			.truecoloralpha {
-				png.pixels[pos] = vpng.TrueColorAlpha {
-					255,
-					0,
-					0,
-					255
-				}
+				png.pixels[pos] = vpng.TrueColorAlpha{255, 0, 0, 255}
 			}
-			else{}
+			else {}
 		}
 	}
 	png.write(os.args[2])

--- a/invert.v
+++ b/invert.v
@@ -1,7 +1,7 @@
 module vpng
 
 fn invert_(mut png PngFile) {
-	for i in 0..(png.pixels.len) {
+	for i in 0 .. (png.pixels.len) {
 		pix := png.pixels[i]
 		match pix {
 			TrueColor {

--- a/mirror.v
+++ b/mirror.v
@@ -3,8 +3,8 @@ module vpng
 fn mirror_vertical_(mut png PngFile) {
 	mut output := []Pixel{}
 
-	for y in 0..(png.height) {
-		for x in 0..(png.width) {
+	for y in 0 .. (png.height) {
+		for x in 0 .. (png.width) {
 			output << png.pixels[y * png.width + (png.width - 1 - x)]
 		}
 	}
@@ -14,8 +14,8 @@ fn mirror_vertical_(mut png PngFile) {
 fn mirror_horizontal_(mut png PngFile) {
 	mut output := []Pixel{}
 
-	for y in 0..(png.height) {
-		for x in 0..(png.width) {
+	for y in 0 .. (png.height) {
+		for x in 0 .. (png.width) {
 			output << png.pixels[((png.width - 1) - y) * png.width + x]
 		}
 	}

--- a/rotate.v
+++ b/rotate.v
@@ -48,17 +48,19 @@ fn rotate_(mut png PngFile, degree f64) {
 			i_ceiling_x := math.ceil(f_true_x)
 			i_ceiling_y := math.ceil(f_true_y)
 
-			if i_floor_x < 0 || i_ceiling_x < 0 || i_floor_x >= png.width || i_ceiling_x >= png.width || i_floor_y < 0 || i_ceiling_y < 0 || i_floor_y >= png.height || i_ceiling_y >= png.height {
+			if i_floor_x < 0 || i_ceiling_x < 0 || i_floor_x >= png.width
+				|| i_ceiling_x >= png.width || i_floor_y < 0 || i_ceiling_y < 0
+				|| i_floor_y >= png.height || i_ceiling_y >= png.height {
 				match png.pixel_type {
 					.truecolor {
-						output << TrueColor {
+						output << TrueColor{
 							red: 0
 							green: 0
 							blue: 0
 						}
 					}
 					.truecoloralpha {
-						output << TrueColorAlpha {
+						output << TrueColorAlpha{
 							red: 0
 							green: 0
 							blue: 0
@@ -78,20 +80,29 @@ fn rotate_(mut png PngFile, degree f64) {
 						clr_bottom_left := png.pixels[int(i_ceiling_y * png.width + i_floor_x)] as TrueColor
 						clr_bottom_right := png.pixels[int(i_ceiling_y * png.width + i_ceiling_x)] as TrueColor
 
-						f_top := TrueColor {
-							red: u8((1 - f_delta_x) * clr_top_left.red + f_delta_x * clr_top_right.red)
-							green: u8((1 - f_delta_x) * clr_top_left.green + f_delta_x * clr_top_right.green)
-							blue: u8((1 - f_delta_x) * clr_top_left.blue + f_delta_x * clr_top_right.blue)
+						f_top := TrueColor{
+							red: u8((1 - f_delta_x) * clr_top_left.red +
+								f_delta_x * clr_top_right.red)
+							green: u8((1 - f_delta_x) * clr_top_left.green +
+								f_delta_x * clr_top_right.green)
+							blue: u8((1 - f_delta_x) * clr_top_left.blue +
+								f_delta_x * clr_top_right.blue)
 						}
-						f_bottom := TrueColor {
-							red: u8((1 - f_delta_x) * clr_bottom_left.red + f_delta_x * clr_bottom_right.red)
-							green: u8((1 - f_delta_x) * clr_bottom_left.green + f_delta_x * clr_bottom_right.green)
-							blue: u8((1 - f_delta_x) * clr_bottom_left.blue + f_delta_x * clr_bottom_right.blue)
+						f_bottom := TrueColor{
+							red: u8((1 - f_delta_x) * clr_bottom_left.red +
+								f_delta_x * clr_bottom_right.red)
+							green: u8((1 - f_delta_x) * clr_bottom_left.green +
+								f_delta_x * clr_bottom_right.green)
+							blue: u8((1 - f_delta_x) * clr_bottom_left.blue +
+								f_delta_x * clr_bottom_right.blue)
 						}
-						output << TrueColor {
-							red: normalize_value(u8((1 - f_delta_y) * f_top.red + f_delta_y * f_bottom.red))
-							green: normalize_value(u8((1 - f_delta_y) * f_top.green + f_delta_y * f_bottom.green))
-							blue: normalize_value(u8((1 - f_delta_y) * f_top.blue + f_delta_y * f_bottom.blue))
+						output << TrueColor{
+							red: normalize_value(u8((1 - f_delta_y) * f_top.red +
+								f_delta_y * f_bottom.red))
+							green: normalize_value(u8((1 - f_delta_y) * f_top.green +
+								f_delta_y * f_bottom.green))
+							blue: normalize_value(u8((1 - f_delta_y) * f_top.blue +
+								f_delta_y * f_bottom.blue))
 						}
 					}
 					.truecoloralpha {
@@ -100,23 +111,35 @@ fn rotate_(mut png PngFile, degree f64) {
 						clr_bottom_left := png.pixels[int(i_ceiling_y * png.width + i_floor_x)] as TrueColorAlpha
 						clr_bottom_right := png.pixels[int(i_ceiling_y * png.width + i_ceiling_x)] as TrueColorAlpha
 
-						f_top := TrueColorAlpha {
-							red: u8((1 - f_delta_x) * clr_top_left.red + f_delta_x * clr_top_right.red)
-							green: u8((1 - f_delta_x) * clr_top_left.green + f_delta_x * clr_top_right.green)
-							blue: u8((1 - f_delta_x) * clr_top_left.blue + f_delta_x * clr_top_right.blue)
-							alpha: u8((1 - f_delta_x) * clr_top_left.alpha + f_delta_x * clr_top_right.alpha)
+						f_top := TrueColorAlpha{
+							red: u8((1 - f_delta_x) * clr_top_left.red +
+								f_delta_x * clr_top_right.red)
+							green: u8((1 - f_delta_x) * clr_top_left.green +
+								f_delta_x * clr_top_right.green)
+							blue: u8((1 - f_delta_x) * clr_top_left.blue +
+								f_delta_x * clr_top_right.blue)
+							alpha: u8((1 - f_delta_x) * clr_top_left.alpha +
+								f_delta_x * clr_top_right.alpha)
 						}
-						f_bottom := TrueColorAlpha {
-							red: u8((1 - f_delta_x) * clr_bottom_left.red + f_delta_x * clr_bottom_right.red)
-							green: u8((1 - f_delta_x) * clr_bottom_left.green + f_delta_x * clr_bottom_right.green)
-							blue: u8((1 - f_delta_x) * clr_bottom_left.blue + f_delta_x * clr_bottom_right.blue)
-							alpha: u8((1 - f_delta_x) * clr_bottom_left.alpha + f_delta_x * clr_bottom_right.alpha)
+						f_bottom := TrueColorAlpha{
+							red: u8((1 - f_delta_x) * clr_bottom_left.red +
+								f_delta_x * clr_bottom_right.red)
+							green: u8((1 - f_delta_x) * clr_bottom_left.green +
+								f_delta_x * clr_bottom_right.green)
+							blue: u8((1 - f_delta_x) * clr_bottom_left.blue +
+								f_delta_x * clr_bottom_right.blue)
+							alpha: u8((1 - f_delta_x) * clr_bottom_left.alpha +
+								f_delta_x * clr_bottom_right.alpha)
 						}
-						output << TrueColorAlpha {
-							red: normalize_value(u8((1 - f_delta_y) * f_top.red + f_delta_y * f_bottom.red))
-							green: normalize_value(u8((1 - f_delta_y) * f_top.green + f_delta_y * f_bottom.green))
-							blue: normalize_value(u8((1 - f_delta_y) * f_top.blue + f_delta_y * f_bottom.blue))
-							alpha: normalize_value(u8((1 - f_delta_y) * f_top.alpha + f_delta_y * f_bottom.alpha))
+						output << TrueColorAlpha{
+							red: normalize_value(u8((1 - f_delta_y) * f_top.red +
+								f_delta_y * f_bottom.red))
+							green: normalize_value(u8((1 - f_delta_y) * f_top.green +
+								f_delta_y * f_bottom.green))
+							blue: normalize_value(u8((1 - f_delta_y) * f_top.blue +
+								f_delta_y * f_bottom.blue))
+							alpha: normalize_value(u8((1 - f_delta_y) * f_top.alpha +
+								f_delta_y * f_bottom.alpha))
 						}
 					}
 					else {

--- a/types.v
+++ b/types.v
@@ -3,6 +3,7 @@ module vpng
 // * zlib bindings *
 #flag -lz
 #include <zlib.h>
+
 struct C.z_stream_s {
 	next_in   voidptr
 	avail_in  u32
@@ -26,7 +27,6 @@ fn C.deflate(&C.z_stream_s, int)
 
 fn C.deflateEnd(&C.z_stream_s)
 
-
 // ****
 pub enum PixelType {
 	indexed
@@ -39,14 +39,14 @@ pub enum PixelType {
 pub type Pixel = Grayscale | GrayscaleAlpha | Indexed | TrueColor | TrueColorAlpha
 
 pub struct PngFile {
-	ihdr       IHDR
+	ihdr IHDR
 pub:
 	width      int
 	height     int
 	pixel_type PixelType
 pub mut:
-	palette    []TrueColor
-	pixels     []Pixel
+	palette []TrueColor
+	pixels  []Pixel
 }
 
 struct InternalPngFile {

--- a/utils.v
+++ b/utils.v
@@ -3,7 +3,7 @@ module vpng
 fn byte_to_int(bytes []u8) int {
 	mut res := 0
 	for i in 0 .. bytes.len {
-		res += bytes[bytes.len - (i + 1)] << ((i) * 8)
+		res += bytes[bytes.len - (i + 1)] << (i * 8)
 	}
 	return res
 }

--- a/vpng.v
+++ b/vpng.v
@@ -2,21 +2,26 @@ module vpng
 
 const png_signature = [u8(0x89), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
 
-pub fn read(filename string) ?PngFile {
+pub fn read(filename string) !PngFile {
 	return parse_(filename)
 }
-pub fn (png PngFile)write(filename string) {
+
+pub fn (png PngFile) write(filename string) {
 	write_(png, filename)
 }
-pub fn (mut png PngFile)rotate(degree f64) {
+
+pub fn (mut png PngFile) rotate(degree f64) {
 	rotate_(mut png, degree)
 }
-pub fn (mut png PngFile)mirror_vertical() {
+
+pub fn (mut png PngFile) mirror_vertical() {
 	mirror_vertical_(mut png)
 }
-pub fn (mut png PngFile)mirror_horizontal() {
+
+pub fn (mut png PngFile) mirror_horizontal() {
 	mirror_horizontal_(mut png)
 }
-pub fn (mut png PngFile)invert() {
+
+pub fn (mut png PngFile) invert() {
 	invert_(mut png)
 }

--- a/write.v
+++ b/write.v
@@ -6,9 +6,7 @@ fn write_(png PngFile, filename string) {
 	mut file_bytes := []u8{}
 	signature(mut file_bytes)
 	write_chunks(mut file_bytes, png)
-	os.write_file(filename, file_bytes.bytestr()) or {
-		println('Error writing file $err')
-	}
+	os.write_file(filename, file_bytes.bytestr()) or { println('Error writing file ${err}') }
 }
 
 fn signature(mut file_bytes []u8) {
@@ -40,9 +38,9 @@ fn iend_chunk(mut file_bytes []u8, mut cs CRC) {
 
 fn idat_chunk(mut file_bytes []u8, mut cs CRC, png PngFile) {
 	mut idat_bytes := []u8{}
-	for y in 0..png.height {
+	for y in 0 .. png.height {
 		idat_bytes << 0
-		for x in 0..png.width {
+		for x in 0 .. png.width {
 			pix := png.pixels[y * png.width + x]
 			match pix {
 				TrueColor {
@@ -65,7 +63,7 @@ fn idat_chunk(mut file_bytes []u8, mut cs CRC, png PngFile) {
 	}
 
 	out_len := idat_bytes.len + idat_bytes.len * 2
-	out := unsafe {malloc(out_len)}
+	out := unsafe { malloc(out_len) }
 	defstream := C.z_stream_s{
 		zalloc: 0
 		zfree: 0
@@ -89,7 +87,7 @@ fn idat_chunk(mut file_bytes []u8, mut cs CRC, png PngFile) {
 			}
 		}
 	}
-	for i in 0 .. (max) {
+	for i in 0 .. max {
 		unsafe {
 			out_bytes << u8(out[i])
 		}


### PR DESCRIPTION
Note: there is one breaking change in the public interface:
```v
-pub fn read(filename string) ?PngFile {
+pub fn read(filename string) !PngFile {
```
Since ?Type and !Type are now split, and the common idiom is to `return err` from the lower levels, if a library can not recover, I think that `!PngFile` is more appropriate, since it will not lose details, about what the problem was.